### PR TITLE
Added MonadFail to make the library compile with newer `base` versions

### DIFF
--- a/src/Data/Colour/Names.hs
+++ b/src/Data/Colour/Names.hs
@@ -185,7 +185,7 @@ import Prelude hiding (tan)
 import Data.Colour.SRGB
 import Data.Colour (black)
 
-readColourName :: (Monad m, Ord a, Floating a) => String -> m (Colour a)
+readColourName :: (Monad m, Ord a, Floating a, MonadFail m) => String -> m (Colour a)
 readColourName "aliceblue" = return aliceblue
 readColourName "antiquewhite" = return antiquewhite
 readColourName "aqua" = return aqua


### PR DESCRIPTION
The `Monad` typeclass does not have the `fail` method in newer `base` versions, so this PR adds a `MonadFail` constraint to account for that.